### PR TITLE
Last row cannot be set to top

### DIFF
--- a/Services/PositionHandler.php
+++ b/Services/PositionHandler.php
@@ -41,7 +41,7 @@ class PositionHandler
                 break;
 
             case 'top':
-                if ($object->getPosition() < $last_position) {
+                if ($object->getPosition() > 0) {
                     $position = 0;
                 }
                 break;


### PR DESCRIPTION
When trying to put last row at top, litteral "top" was used in the query instead of "0" value.
