### PR TITLE
Fix PHP 5.3 compatibility, clean up duplicated code

### DIFF
--- a/Services/PositionHandler.php
+++ b/Services/PositionHandler.php
@@ -89,6 +89,18 @@ abstract class PositionHandler
     }
 
     /**
+     * @param $entity
+     *
+     * @return int
+     */
+    public function getCurrentPosition($entity)
+    {
+        $getter = sprintf('get%s', ucfirst($this->getPositionFieldByEntity($entity)));
+
+        return $entity->{$getter}();
+    }
+
+    /**
      * @param object $object
      * @param string $movePosition
      * @param int    $lastPosition
@@ -97,30 +109,30 @@ abstract class PositionHandler
      */
     public function getPosition($object, $movePosition, $lastPosition)
     {
-        $getter = sprintf('get%s', ucfirst($this->getPositionFieldByEntity($object)));
+        $currentPosition = $this->getCurrentPosition($object);
         $newPosition = 0;
 
         switch ($movePosition) {
             case 'up' :
-                if ($object->{$getter}() > 0) {
-                    $newPosition = $object->{$getter}() - 1;
+                if ($currentPosition > 0) {
+                    $newPosition = $currentPosition - 1;
                 }
                 break;
 
             case 'down':
-                if ($object->{$getter}() < $lastPosition) {
-                    $newPosition = $object->{$getter}() + 1;
+                if ($currentPosition < $lastPosition) {
+                    $newPosition = $currentPosition + 1;
                 }
                 break;
 
             case 'top':
-                if ($object->{$getter}() > 0) {
+                if ($currentPosition > 0) {
                     $newPosition = 0;
                 }
                 break;
 
             case 'bottom':
-                if ($object->{$getter}() < $lastPosition) {
+                if ($currentPosition < $lastPosition) {
                     $newPosition = $lastPosition;
                 }
                 break;

--- a/Twig/ObjectPositionExtension.php
+++ b/Twig/ObjectPositionExtension.php
@@ -6,7 +6,7 @@ use Pix\SortableBehaviorBundle\Services\PositionHandler;
 
 /**
  * Description of ObjectPositionExtension
- * 
+ *
  * @author Volker von Hoesslin <volker.von.hoesslin@empora.com>
  */
 class ObjectPositionExtension extends \Twig_Extension
@@ -42,15 +42,22 @@ class ObjectPositionExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('currentObjectPosition', function ($entity) {
-                $getter = sprintf('get%s', ucfirst($this->positionHandler->getPositionFieldByEntity($entity)));
-
-                return $entity->{$getter}();
-            }),
-
-            new \Twig_SimpleFunction('lastPosition', function ($entity) {
-                return $this->positionHandler->getLastPosition($entity);
-            }),
+            new \Twig_SimpleFunction('currentObjectPosition', array($this, 'currentPosition')),
+            new \Twig_SimpleFunction('lastPosition', array($this, 'lastPosition'))
         );
+    }
+
+    /**
+     * @return int
+     */
+    private function currentPosition($entity) {
+        return $this->positionHandler->getCurrentPosition($entity);
+    }
+
+    /**
+     * @return int
+     */
+    private function lastPosition($entity) {
+        return $this->positionHandler->getLastPosition($entity);
     }
 }


### PR DESCRIPTION
Moved the code needed to get the current position of an object to its own method on positionHandler to avoid code duplication.

Closes #19 because it no longer uses $this inside an anonymous function.