### PR TITLE
Changed method visibility to public on object extension

### DIFF
--- a/Twig/ObjectPositionExtension.php
+++ b/Twig/ObjectPositionExtension.php
@@ -50,14 +50,14 @@ class ObjectPositionExtension extends \Twig_Extension
     /**
      * @return int
      */
-    private function currentPosition($entity) {
+    public function currentPosition($entity) {
         return $this->positionHandler->getCurrentPosition($entity);
     }
 
     /**
      * @return int
      */
-    private function lastPosition($entity) {
+    public function lastPosition($entity) {
         return $this->positionHandler->getLastPosition($entity);
     }
 }


### PR DESCRIPTION
On the previous PR #53 I made a mistake, those functions should be public to be able to use them.

If not, twig crashes.