### PR TITLE
Improve up/down icons

### DIFF
--- a/Resources/views/Default/_sort.html.twig
+++ b/Resources/views/Default/_sort.html.twig
@@ -4,25 +4,25 @@
 
     {% if current_position < last_position %}
         <a class="btn btn-sm btn-default" href="{{ admin.generateObjectUrl('move', object, {'position': 'bottom'}) }}" title="{{ 'move_to_bottom'|trans }}">
-            <i class="fa fa-arrow-down"></i>
+            <i class="fa fa-angle-double-down"></i>
         </a>
     {% endif %}
 
     {% if current_position < last_position %}
         <a class="btn btn-sm btn-default" href="{{ admin.generateObjectUrl('move', object, {'position': 'down'}) }}" title="{{ 'move_down'|trans }}">
-            <i class="fa fa-long-arrow-down"></i>
+            <i class="fa fa-angle-down"></i>
         </a>
     {% endif %}
 
     {% if current_position > 0 %}
         <a class="btn btn-sm btn-default" href="{{ admin.generateObjectUrl('move', object, {'position': 'up'}) }}" title="{{ 'move_up'|trans }}">
-            <i class="fa fa-long-arrow-up"></i>
+            <i class="fa fa-angle-up"></i>
         </a>
     {% endif %}
 
     {% if current_position > 0 %}
         <a class="btn btn-sm btn-default" href="{{ admin.generateObjectUrl('move', object, {'position': 'top'}) }}" title="{{ 'move_to_top'|trans }}">
-            <i class="fa fa-arrow-up"></i>
+            <i class="fa fa-angle-double-up"></i>
         </a>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
This is just to improve the previous icons of up and down to a better ones.

Before:
![captura de pantalla 2017-01-19 a las 21 16 23](https://cloud.githubusercontent.com/assets/1137485/22123810/76cd9e5a-de8d-11e6-87fa-3e0f7e92011e.png)

After:
![captura de pantalla 2017-01-19 a las 21 18 24](https://cloud.githubusercontent.com/assets/1137485/22123815/7b45787c-de8d-11e6-97d4-9dfc660f8924.png)

I think now it's clearer what they do.