### PR TITLE
Fixed redirect response when there isn't enough permissions

### DIFF
--- a/Controller/SortableAdminController.php
+++ b/Controller/SortableAdminController.php
@@ -39,7 +39,10 @@ class SortableAdminController extends CRUDController
                 $translator->trans('flash_error_no_rights_update_position')
             );
 
-            return new RedirectResponse($this->admin->generateUrl('list', $this->admin->getFilterParameters()));
+            return new RedirectResponse($this->admin->generateUrl(
+                'list',
+                array('filter' => $this->admin->getFilterParameters())
+            ));
         }
 
         /** @var PositionHandler $positionHandler */


### PR DESCRIPTION
There are two redirect responses on SortableAdminController, both are the same, but were written different. This PR unifies this with the correct call.