### PR TITLE
Added the ability to define your own positionHandler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,11 @@ class Configuration implements ConfigurationInterface
                 ->cannotBeEmpty()
                 ->defaultValue('orm')
             ->end()
+
+            ->scalarNode('position_handler')
+                ->defaultNull()
+            ->end()
+
             ->arrayNode('position_field')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/DependencyInjection/PixSortableBehaviorExtension.php
+++ b/DependencyInjection/PixSortableBehaviorExtension.php
@@ -37,11 +37,10 @@ class PixSortableBehaviorExtension extends Extension
         $container->setParameter('pix.sortable.behavior.position.field', $config['position_field']);
         $container->setParameter('pix.sortable.behavior.sortable_groups', $config['sortable_groups']);
 
-        $positionHandler = sprintf(
-            'pix_sortable_behavior.position.%s',
-            $config['db_driver']
-        );
-
-        $container->setAlias('pix_sortable_behavior.position', new Alias($positionHandler));
+        $positionHandler = sprintf('pix_sortable_behavior.position.%s', $config['db_driver']);
+        if ($config['position_handler']) {
+            $positionHandler = $config['position_handler'];
+        }
+        $container->setAlias('pix_sortable_behavior.position', $positionHandler);
     }
 }

--- a/Services/PositionHandler.php
+++ b/Services/PositionHandler.php
@@ -113,7 +113,7 @@ abstract class PositionHandler
         $newPosition = 0;
 
         switch ($movePosition) {
-            case 'up' :
+            case 'up':
                 if ($currentPosition > 0) {
                     $newPosition = $currentPosition - 1;
                 }

--- a/Services/PositionORMHandler.php
+++ b/Services/PositionORMHandler.php
@@ -85,11 +85,12 @@ class PositionORMHandler extends PositionHandler
     {
         $cacheKey = ClassUtils::getClass($entity);
 
-        foreach ($groups as $groupName) {
-            $getter = 'get' . $groupName;
+        foreach ($groups as $group) {
+            $getter = 'get' . ucfirst($group);
 
             if ($entity->$getter()) {
-                $cacheKey .= '_' . $entity->$getter()->getId();
+                $data = $entity->$getter();
+                $cacheKey .= '_' . is_object($data) ? $data->getId() : $data;
             }
         }
 


### PR DESCRIPTION
With this one we can override the default positionHandler if we need it.

My use case is that I use gedmo sortable and It has a specific logic to define positions. This logic does not work when using class inheritance for example, so I did a custom positionHandler that replicates Gedmo's logic to make it work.

The other change allows to use SortableGroup on a non entity field (ex. string)