### PR TITLE
Feature: Add class to body while dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Also include the JavaScript needed for this to work, in your ```theme.yml``` fil
 ```
 
 Adding the JavaScript and the template, will give you the possibility to drag items in a tablelist.
-In case you need it, this plugin fires to jQuery events when dragging is done on the ```$(document)``` element, so if you want to add custom notification, that is possible.
+In case you need it, this plugin fires to jQuery events when dragging is done on the ```$(document)``` element, so if you want to add custom notification, that is possible. Also, when dragging the ```<body>``` gets an ```is-dragging``` class. This class is removed when you stop dragging. This could by quite handy if you have some custom js/css.
 ```
 pixSortableBehaviorBundle.success
 pixSortableBehaviorBundle.error

--- a/Resources/public/js/init.js
+++ b/Resources/public/js/init.js
@@ -19,6 +19,14 @@ var DraggableTable = function () {
 DraggableTable.prototype.init = function (node, settings) {
     $(node).sortable({
         'handle': '.js-sortable-move',
+        'start': function() {
+            $('body').addClass('is-dragging');
+        },
+        'stop': function() {
+            setTimeout(function() {
+                $('body').removeClass('is-dragging')
+            }, 100);
+        },
         'axis': 'y',
         'cancel': 'input,textarea,select,option,button:not(.js-sortable-move)',
         'tolerance': 'pointer',


### PR DESCRIPTION
We're using the drag & drop feature from this package quite often; works awesome. Thanks for your work.

We're having some problems with our custom js/css.
That's why i've implemented a custom ```is-dragging``` class on the body while dragging. This class is added to the body when started, en removed when ended. Small feature; but could be quite usefull if you've some custom stuff going on.