### PR TITLE
Bugfix: Add right order even when having pagination and drag and drop.

### DIFF
--- a/Resources/public/js/init.js
+++ b/Resources/public/js/init.js
@@ -17,7 +17,15 @@ var DraggableTable = function () {
 };
 
 DraggableTable.prototype.init = function (node, settings) {
-    $(node).sortable({
+    var element = $(node);
+    var movers = $('.js-sortable-move');
+    if (movers.length <= 1) return;
+
+    var first = parseInt(movers.first().attr('data-current-position'));
+    var last = parseInt(movers.last().attr('data-current-position'));
+    var direction = first <= last ? 1 : -1;
+
+    element.sortable({
         'handle': '.js-sortable-move',
         'axis': 'y',
         'cancel': 'input,textarea,select,option,button:not(.js-sortable-move)',
@@ -34,8 +42,12 @@ DraggableTable.prototype.init = function (node, settings) {
             return ui;
         },
         'update': function(event, ui) {
+            $('.js-sortable-move').each(function(index, item) {
+                $(item).attr('data-current-position', first + (index * direction));
+            });
+
             var moved = $(ui.item).find('.js-sortable-move');
-            var newPosition = ui.item.index();
+            var newPosition = moved.attr('data-current-position');
 
             $.ajax({
                 'type': 'GET',
@@ -48,7 +60,6 @@ DraggableTable.prototype.init = function (node, settings) {
                     $(document).trigger("pixSortableBehaviorBundle.error",[data]);
                 }
             });
-
         }
     }).disableSelection();
 };

--- a/Resources/views/Default/_sort_drag_drop.html.twig
+++ b/Resources/views/Default/_sort_drag_drop.html.twig
@@ -3,8 +3,7 @@
     {% set last_position    = lastPosition(object) %}
     {% set enable_top_bottom_buttons = field_description.options.actions.move.enable_top_bottom_buttons ?? true %}
 
-    
-    <span class="btn btn-sm btn-default js-sortable-move" data-url="{{ admin.generateObjectUrl('move', object, {'position': 'NEW_POSITION'}) }}">
+    <span class="btn btn-sm btn-default js-sortable-move" data-current-position="{{ current_position }}" data-url="{{ admin.generateObjectUrl('move', object, {'position': 'NEW_POSITION'}) }}">
         <i class="fa fa-arrows"></i>
     </span>
     


### PR DESCRIPTION
We noticed an bug when using the Drag 'N Drop feature. We've fixed this bug using this Pull Request. What was happening what the JS of the Drag 'N Drop feature used the current index() to determine the new position of the dragged item. When paginating, the index() of each item isn't the current order, it's just the order of the current paginated page. This Pull Request fixes this bug by using min/max values to determine the right order.

This is fully 100% Backwards Compatible, please merge it in as soon as possible.