### PR TITLE
Refactor: cleanup init, fix selectors and add events

### DIFF
--- a/Resources/public/js/init.js
+++ b/Resources/public/js/init.js
@@ -1,38 +1,35 @@
 $(function() {
-    $('.sonata-ba-list tbody').draggableTable();
+    $('.sonata-ba-list').draggableTable();
 });
 
-$.fn.draggableTable = function (settings) {
+$.fn.draggableTable = function() {
     $(this).each(function (index, item) {
         item = $(item);
-        var instance = item.data('DraggableTable');
-        if (!instance) {
-            item.data('DraggableTable', new DraggableTable(this, settings));
+        if (!item.data('DraggableTable')) {
+            item.data('DraggableTable', new DraggableTable(item));
         }
     });
 };
 
-var DraggableTable = function () {
-    this.init.apply(this, arguments);
-};
-
-DraggableTable.prototype.init = function (node, settings) {
-    var element = $(node);
-    var movers = $('.js-sortable-move');
+var DraggableTable = function(element) {
+    var movers = element.find('.js-sortable-move');
     if (movers.length <= 1) return;
+
+    var $document = $(document);
+    var $body = $(document.body);
 
     var first = parseInt(movers.first().attr('data-current-position'));
     var last = parseInt(movers.last().attr('data-current-position'));
     var direction = first <= last ? 1 : -1;
 
-    element.sortable({
+    element.find('tbody').sortable({
         'handle': '.js-sortable-move',
         'start': function() {
-            $('body').addClass('is-dragging');
+            $body.addClass('is-dragging');
         },
         'stop': function() {
             setTimeout(function() {
-                $('body').removeClass('is-dragging')
+                $body.removeClass('is-dragging');
             }, 100);
         },
         'axis': 'y',
@@ -42,7 +39,7 @@ DraggableTable.prototype.init = function (node, settings) {
         'cursor': 'move',
         'zIndex': 1,
         'helper': function(e, ui) {
-            ui.css('width','100%');
+            ui.css('width', '100%');
             ui.children().each(function() {
                 var item = $(this);
                 item.width(item.width());
@@ -50,22 +47,27 @@ DraggableTable.prototype.init = function (node, settings) {
             return ui;
         },
         'update': function(event, ui) {
-            $('.js-sortable-move').each(function(index, item) {
+            element.find('.js-sortable-move').each(function(index, item) {
                 $(item).attr('data-current-position', first + (index * direction));
             });
 
             var moved = $(ui.item).find('.js-sortable-move');
             var newPosition = moved.attr('data-current-position');
 
+            $document.trigger('pixSortableBehaviorBundle.update', [event, ui]);
+            
             $.ajax({
                 'type': 'GET',
-                'url': moved.data('url').replace('NEW_POSITION', newPosition),
+                'url': moved.attr('data-url').replace('NEW_POSITION', newPosition),
                 'dataType': 'json',
-                'success': function(data) {
-                    $(document).trigger("pixSortableBehaviorBundle.success", [data]);
-                },
                 'error': function(data) {
-                    $(document).trigger("pixSortableBehaviorBundle.error",[data]);
+                    $document.trigger('pixSortableBehaviorBundle.error', [data]);
+                },
+                'success': function(data) {
+                    $document.trigger('pixSortableBehaviorBundle.success', [data]);
+                },
+                'complete': function() {
+                    $document.trigger('pixSortableBehaviorBundle.complete');
                 }
             });
         }


### PR DESCRIPTION
- Remove unnecessary init method
- Remove unused settings parameter
- Select movers inside element. Just in case there are multiple DraggableTables on one page, this will prevent selecting movers from both.
- Add $body and $document vars
- Add update and complete events