### PR TITLE
Fixed readme position_field

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ pix_sortable_behavior:
     position_field:
         default: sort #default value : position
         entities:
-            AppBundle/Entity/Foobar: order
-            AppBundle/Entity/Baz: rang
+            AppBundle\Entity\Foobar: order
+            AppBundle\Entity\Baz: rang
     sortable_groups:
         entities:
             AppBundle/Entity/Baz: [ group ]


### PR DESCRIPTION
The position_field entities should be with "\".
With "/", it doesn`t work