### PR TITLE
Extend AbstractExtension instead of using Twig_Extension

### DIFF
--- a/Twig/ObjectPositionExtension.php
+++ b/Twig/ObjectPositionExtension.php
@@ -3,13 +3,14 @@
 namespace Pix\SortableBehaviorBundle\Twig;
 
 use Pix\SortableBehaviorBundle\Services\PositionHandler;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Description of ObjectPositionExtension
  *
  * @author Volker von Hoesslin <volker.von.hoesslin@empora.com>
  */
-class ObjectPositionExtension extends \Twig_Extension
+class ObjectPositionExtension extends AbstractExtension
 {
     const NAME = 'sortableObjectPosition';
 

--- a/Twig/ObjectPositionExtension.php
+++ b/Twig/ObjectPositionExtension.php
@@ -4,6 +4,7 @@ namespace Pix\SortableBehaviorBundle\Twig;
 
 use Pix\SortableBehaviorBundle\Services\PositionHandler;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Description of ObjectPositionExtension
@@ -43,8 +44,8 @@ class ObjectPositionExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('currentObjectPosition', array($this, 'currentPosition')),
-            new \Twig_SimpleFunction('lastPosition', array($this, 'lastPosition'))
+            new TwigFunction('currentObjectPosition', array($this, 'currentPosition')),
+            new TwigFunction('lastPosition', array($this, 'lastPosition'))
         );
     }
 


### PR DESCRIPTION
Twig_Extension is deprecated and to remove `twig/extensions` this needs to go